### PR TITLE
Added new register switching function to allow for multiple sensors.

### DIFF
--- a/src/MPU6050_light.cpp
+++ b/src/MPU6050_light.cpp
@@ -1,6 +1,6 @@
 /* MPU6050_light library for Arduino
  * 
- * Authors: Romain JL. Fétick (github.com/rfetick)
+ * Authors: Romain JL. FÃ©tick (github.com/rfetick)
  *              simplifications and corrections
  *          Tockn (github.com/tockn)
  *              initial author (v1.5.2)
@@ -9,29 +9,23 @@
 #include "MPU6050_light.h"
 #include "Arduino.h"
 
-/* Wrap an angle in the range [-limit,+limit] (special thanks to Edgar Bonet!) */
-static float wrap(float angle,float limit){
-  while (angle >  limit) angle -= 2*limit;
-  while (angle < -limit) angle += 2*limit;
-  return angle;
-}
-
 /* INIT and BASIC FUNCTIONS */
 
 MPU6050::MPU6050(TwoWire &w){
+  readReg = 0x68;
   wire = &w;
   setFilterGyroCoef(DEFAULT_GYRO_COEFF);
   setGyroOffsets(0,0,0);
   setAccOffsets(0,0,0);
+  
 }
 
 byte MPU6050::begin(int gyro_config_num, int acc_config_num){
-  // changed calling register sequence [https://github.com/rfetick/MPU6050_light/issues/1] -> thanks to augustosc
-  byte status = writeData(MPU6050_PWR_MGMT_1_REGISTER, 0x01); // check only the first connection with status
   writeData(MPU6050_SMPLRT_DIV_REGISTER, 0x00);
   writeData(MPU6050_CONFIG_REGISTER, 0x00);
   setGyroConfig(gyro_config_num);
   setAccConfig(acc_config_num);
+  byte status = writeData(MPU6050_PWR_MGMT_1_REGISTER, 0x01); // check only the last connection with status
   
   this->update();
   angleX = this->getAccAngleX();
@@ -41,7 +35,7 @@ byte MPU6050::begin(int gyro_config_num, int acc_config_num){
 }
 
 byte MPU6050::writeData(byte reg, byte data){
-  wire->beginTransmission(MPU6050_ADDR);
+  wire->beginTransmission(readReg);
   wire->write(reg);
   wire->write(data);
   byte status = wire->endTransmission();
@@ -50,32 +44,48 @@ byte MPU6050::writeData(byte reg, byte data){
 
 // This method is not used internaly, maybe by user...
 byte MPU6050::readData(byte reg) {
-  wire->beginTransmission(MPU6050_ADDR);
+  wire->beginTransmission(readReg);
   wire->write(reg);
   wire->endTransmission(true);
-  wire->requestFrom(MPU6050_ADDR, 1);
+  wire->requestFrom(readReg, 1);
   byte data =  wire->read();
   return data;
 }
 
 /* SETTER */
 
+byte MPU6050::switchReadingAddress(){
+	byte status;
+	switch(readReg){
+	case 0x68:
+	  readReg = 0x69;
+	  break;
+	case 0x69:
+	  readReg = 0x68;
+	  break;
+	default: // error
+	  status = 1;
+	  break;
+	}
+	return status;
+}
+
 byte MPU6050::setGyroConfig(int config_num){
   byte status;
   switch(config_num){
-    case 0: // range = +- 250 °/s
+    case 0: // range = +- 250 Â°/s
 	  gyro_lsb_to_degsec = 131.0;
 	  status = writeData(MPU6050_GYRO_CONFIG_REGISTER, 0x00);
 	  break;
-	case 1: // range = +- 500 °/s
+	case 1: // range = +- 500 Â°/s
 	  gyro_lsb_to_degsec = 65.5;
 	  status = writeData(MPU6050_GYRO_CONFIG_REGISTER, 0x08);
 	  break;
-	case 2: // range = +- 1000 °/s
+	case 2: // range = +- 1000 Â°/s
 	  gyro_lsb_to_degsec = 32.8;
 	  status = writeData(MPU6050_GYRO_CONFIG_REGISTER, 0x10);
 	  break;
-	case 3: // range = +- 2000 °/s
+	case 3: // range = +- 2000 Â°/s
 	  gyro_lsb_to_degsec = 16.4;
 	  status = writeData(MPU6050_GYRO_CONFIG_REGISTER, 0x18);
 	  break;
@@ -167,10 +177,10 @@ void MPU6050::calcOffsets(bool is_calc_gyro, bool is_calc_acc){
 /* UPDATE */
 
 void MPU6050::fetchData(){
-  wire->beginTransmission(MPU6050_ADDR);
+  wire->beginTransmission(readReg);
   wire->write(MPU6050_ACCEL_OUT_REGISTER);
   wire->endTransmission(false);
-  wire->requestFrom((int)MPU6050_ADDR, 14);
+  wire->requestFrom((int)readReg, 14);
 
   int16_t rawData[7]; // [ax,ay,az,temp,gx,gy,gz]
 
@@ -181,7 +191,7 @@ void MPU6050::fetchData(){
 
   accX = ((float)rawData[0]) / acc_lsb_to_g - accXoffset;
   accY = ((float)rawData[1]) / acc_lsb_to_g - accYoffset;
-  accZ = (!upsideDownMounting - upsideDownMounting) * ((float)rawData[2]) / acc_lsb_to_g - accZoffset;
+  accZ = ((float)rawData[2]) / acc_lsb_to_g - accZoffset;
   temp = (rawData[3] + TEMP_LSB_OFFSET) / TEMP_LSB_2_DEGREE;
   gyroX = ((float)rawData[4]) / gyro_lsb_to_degsec - gyroXoffset;
   gyroY = ((float)rawData[5]) / gyro_lsb_to_degsec - gyroYoffset;
@@ -192,19 +202,17 @@ void MPU6050::update(){
   // retrieve raw data
   this->fetchData();
   
-  // estimate tilt angles: this is an approximation for small angles!
-  float sgZ = (accZ>=0)-(accZ<0); // allow one angle to go from -180° to +180°
-  angleAccX =   atan2(accY, sgZ*sqrt(accZ*accZ + accX*accX)) * RAD_2_DEG; // [-180°,+180°]
-  angleAccY = - atan2(accX,     sqrt(accZ*accZ + accY*accY)) * RAD_2_DEG; // [- 90°,+ 90°]
+  // process data to get angles
+  float sgZ = (accZ>=0)-(accZ<0);
+  angleAccX = atan2(accY, sgZ*sqrt(accZ*accZ + accX*accX)) * RAD_2_DEG;
+  angleAccY = - atan2(accX, sqrt(accZ*accZ + accY*accY)) * RAD_2_DEG;
 
   unsigned long Tnew = millis();
   float dt = (Tnew - preInterval) * 1e-3;
   preInterval = Tnew;
 
-  // Correctly wrap X and Y angles (special thanks to Edgar Bonet!)
-  // https://github.com/gabriel-milan/TinyMPU6050/issues/6
-  angleX = wrap(filterGyroCoef*(angleAccX + wrap(angleX +     gyroX*dt - angleAccX,180)) + (1.0-filterGyroCoef)*angleAccX,180);
-  angleY = wrap(filterGyroCoef*(angleAccY + wrap(angleY + sgZ*gyroY*dt - angleAccY, 90)) + (1.0-filterGyroCoef)*angleAccY, 90);
-  angleZ += gyroZ*dt; // not wrapped (to do???)
+  angleX = (filterGyroCoef*(angleX + gyroX*dt)) + ((1.0-filterGyroCoef)*angleAccX);
+  angleY = (filterGyroCoef*(angleY + gyroY*dt)) + ((1.0-filterGyroCoef)*angleAccY);
+  angleZ += gyroZ*dt;
 
 }

--- a/src/MPU6050_light.h
+++ b/src/MPU6050_light.h
@@ -3,10 +3,10 @@
  *
  * Mapping of the different gyro and accelero configurations:
  *
- * GYRO_CONFIG_[0,1,2,3] range = +- [250, 500,1000,2000] °/s
- *                       sensi =    [131,65.5,32.8,16.4] bit/(°/s)
+ * GYRO_CONFIG_[0,1,2,3] range = +- [250, 500,1000,2000] Â°/s
+ *                       sensi =    [131,65.5,32.8,16.4] bit/(Â°/s)
  *
- * ACC_CONFIG_[0,1,2,3] range = +- [    2,   4,   8,  16] times the gravity (9.81m/s²)
+ * ACC_CONFIG_[0,1,2,3] range = +- [    2,   4,   8,  16] times the gravity (9.81m/sÂ²)
  *                      sensi =    [16384,8192,4096,2048] bit/gravity
 */
 
@@ -16,7 +16,6 @@
 #include "Arduino.h"
 #include "Wire.h"
 
-#define MPU6050_ADDR                  0x68
 #define MPU6050_SMPLRT_DIV_REGISTER   0x19
 #define MPU6050_CONFIG_REGISTER       0x1a
 #define MPU6050_GYRO_CONFIG_REGISTER  0x1b
@@ -26,7 +25,7 @@
 #define MPU6050_GYRO_OUT_REGISTER     0x43
 #define MPU6050_ACCEL_OUT_REGISTER    0x3B
 
-#define RAD_2_DEG             57.29578 // [°/rad]
+#define RAD_2_DEG             57.29578 // [Â°/rad]
 #define CALIB_OFFSET_NB_MES   500
 #define TEMP_LSB_2_DEGREE     340.0    // [bit/celsius]
 #define TEMP_LSB_OFFSET       12412.0
@@ -55,6 +54,9 @@ class MPU6050{
 	
 	void setFilterGyroCoef(float gyro_coeff);
 	void setFilterAccCoef(float acc_coeff);
+	
+	//	MODIFY READING REGISTER
+	byte switchReadingAddress();
 
 	// MPU CONFIG GETTER
 	float getGyroXoffset(){ return gyroXoffset; };
@@ -68,7 +70,7 @@ class MPU6050{
 	float getFilterGyroCoef(){ return filterGyroCoef; };
 	float getFilterAccCoef(){ return 1.0-filterGyroCoef; };
 	
-	// DATA GETTER
+	// INLOOP GETTER
     float getTemp(){ return temp; };
 
     float getAccX(){ return accX; };
@@ -89,9 +91,6 @@ class MPU6050{
 	// INLOOP UPDATE
 	void fetchData(); // user should better call 'update' that includes 'fetchData'
     void update();
-	
-	// UPSIDE DOWN MOUNTING
-	bool upsideDownMounting = false;
 
 
   private:
@@ -103,7 +102,9 @@ class MPU6050{
     float angleAccX, angleAccY;
     float angleX, angleY, angleZ;
     long preInterval;
-    float filterGyroCoef; // complementary filter coefficient to balance gyro vs accelero data to get angle
+    float filterGyroCoef;
+    byte readReg;
+	 // complementary filter coefficient to balance gyro vs accelero data to get angle
 };
 
 #endif


### PR DESCRIPTION
This modification was made off of the Arduino library function so some more recent features may not be available for it. This small tweak allows for a the reading register to be switched from 0x68 to 0x69. To switch your MPU_6050 board to register 0x69 just set the AD0 pin to HIGH then to switch back set it to 0x68, set AD0 to LOW. 
This allows for a register swap, so if you only want 1 sensor the library is still the same but if you want 2, you can follow the following protocol:
Call `MPU6050::switchReadingAddress()`
For all of the sensors, set their AD0 pins to LOW
Now the system is set up, you can now set a specific sensor to read from
To read from sensor "x", just set sensor "x"'s AD0 pin to HIGH

To re-enter single sensor mode just re-call `MPU6050::switchReadingAddress()`